### PR TITLE
Change name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vtinfo",
+  "name": "@mapbox/vtinfo",
   "version": "0.0.1",
   "description": "Get general information and stats about a particular vector tile buffer.",
   "main": "./lib/index.js",


### PR DESCRIPTION
node-pre-gyp tries to put this in `vtinfo` buckets, but looks for it during installs at `@mapbox/vtinfo`. Changing the name in the package.json solves that problem.

cc/ @mapsam @springmeyer 
