### PR TITLE
Include dirs

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
       'sources': [ './src/vtinfo.cpp' ],
       'include_dirs': [
         '<!(node -e \'require("nan")\')',
-        'node_modules/protozero/include'
+        '<!(node -e \'require("protozero")\')'
       ],
       'ldflags': [
         '-Wl,-z,now',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "nan": "^2.3.5",
     "node-pre-gyp": "^0.6.28",
-    "protozero": "https://github.com/mapbox/protozero/tarball/include_dirs"
+    "protozero": "~1.4.1"
   },
   "devDependencies": {
     "aws-sdk": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "nan": "^2.3.5",
     "node-pre-gyp": "^0.6.28",
-    "protozero": "^1.3.0"
+    "protozero": "https://github.com/mapbox/protozero/tarball/include_dirs"
   },
   "devDependencies": {
     "aws-sdk": "^2.4.6",


### PR DESCRIPTION
Include protozero with a require now that it has `include_dirs.js`.

cc @springmeyer @GretaCB 
