### PR TITLE
include keys for each layer

### DIFF
--- a/test/vtinfo.test.js
+++ b/test/vtinfo.test.js
@@ -11,6 +11,11 @@ test('reads the buffer as expected', function(t) {
   t.equal(info.layers[0].version, 2, 'version converted properly');
   t.equal(info.layers[0].polygon_features, 5, 'geometry counts stored properly');
   t.equal(info.layers[0].features, 5, 'total feature count');
+  t.equal(info.layers[0].keys[0], 'class', 'expected key value in array');
+
+  info.layers.forEach(function(l) {
+    console.log(l.keys);
+  });
   t.end();
 });
 

--- a/test/vtinfo.test.js
+++ b/test/vtinfo.test.js
@@ -12,10 +12,6 @@ test('reads the buffer as expected', function(t) {
   t.equal(info.layers[0].polygon_features, 5, 'geometry counts stored properly');
   t.equal(info.layers[0].features, 5, 'total feature count');
   t.equal(info.layers[0].keys[0], 'class', 'expected key value in array');
-
-  info.layers.forEach(function(l) {
-    console.log(l.keys);
-  });
   t.end();
 });
 


### PR DESCRIPTION
Adds a `keys` property to each feature returned, which is an Array of strings.

refs #10 

cc @springmeyer @GretaCB 
