### PR TITLE
bundle node-pre-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ matrix:
     # coverage
     - os: linux
       env: COVERAGE=true CXXFLAGS="--coverage" LDFLAGS="--coverage" NPM_FLAGS="--debug"
-    # sanitizer
-    - os: linux
-      env: NODE_ASAN=true CXXFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" NPM_FLAGS="--debug"
     # publishing
     - os: linux
       env: PUBLISHABLE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ script:
   - ASAN_OPTIONS=detect_leaks=1 npm test
   - |
     if [ -n "${COVERAGE}" ]; then
+      mason install llvm-cov 3.9.1
+      export PATH+$(mason prefix llvm-cov 3.9.1)/bin:${PATH}
       which llvm-cov
       curl -S -f https://codecov.io/bash -o codecov
       chmod +x codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - |
     if [ -n "${COVERAGE}" ]; then
       mason install llvm-cov 3.9.1
-      export PATH+$(mason prefix llvm-cov 3.9.1)/bin:${PATH}
+      export PATH=$(mason prefix llvm-cov 3.9.1)/bin:${PATH}
       which llvm-cov
       curl -S -f https://codecov.io/bash -o codecov
       chmod +x codecov

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "test": "tape test/*.test.js",
-    "preinstall": "npm install node-pre-gyp",
+    "prepublish": "npm ls",
     "install": "node-pre-gyp install --fallback-to-build"
   },
   "homepage": "https://github.com/mapbox/vtinfo",
@@ -20,6 +20,7 @@
     "node-pre-gyp": "^0.6.28",
     "protozero": "~1.4.1"
   },
+  "bundledDependencies":["node-pre-gyp"],
   "devDependencies": {
     "aws-sdk": "^2.4.6",
     "tape": "^4.5.1"

--- a/scripts/travis_setup.sh
+++ b/scripts/travis_setup.sh
@@ -20,7 +20,7 @@ function init_binary() {
 function main() {
     setup_mason
     if [[ $(uname -s) == 'Linux' ]]; then
-        init_binary clang 3.9.1
+        init_binary clang++ 3.9.1
         export CXX=clang++
         export CC=clang
     fi

--- a/scripts/travis_setup.sh
+++ b/scripts/travis_setup.sh
@@ -6,13 +6,8 @@ set -o pipefail
 MASON_VERSION="master"
 
 function setup_mason() {
-    if [[ ! -d ./.mason ]]; then
-        git clone https://github.com/mapbox/mason.git ./.mason
-        (cd ./.mason && git checkout ${MASON_VERSION})
-    else
-        echo "Updating to latest mason"
-        (cd ./.mason && git fetch && git checkout ${MASON_VERSION})
-    fi
+    mkdir -p ./.mason
+    curl -sSfL https://github.com/mapbox/mason/archive/v0.10.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./.mason
     export PATH=$(pwd)/.mason:$PATH
 }
 
@@ -25,7 +20,7 @@ function init_binary() {
 function main() {
     setup_mason
     if [[ $(uname -s) == 'Linux' ]]; then
-        init_binary clang 3.8.0
+        init_binary clang 3.9.1
         export CXX=clang++
         export CC=clang
     fi


### PR DESCRIPTION
The best practice about how to install node-pre-gyp has shifted recently. The correct approach is bundling which is clear in the readme after mapbox/node-pre-gyp#269.